### PR TITLE
Added half-duplex SPI mode (i.e. on iMX233-Olinuxino-Nano) - currentl…

### DIFF
--- a/include/librfid/rfid_reader_spidev.h
+++ b/include/librfid/rfid_reader_spidev.h
@@ -3,4 +3,6 @@
 
 extern struct rfid_reader rfid_reader_spidev;
 
+#define SPIDEV_HALFDUPLEX
+
 #endif

--- a/src/rfid_asic_rc632.c
+++ b/src/rfid_asic_rc632.c
@@ -753,6 +753,11 @@ rc632_init(struct rfid_asic_handle *ah)
 {
 	int ret;
 
+	/* disable register paging */
+	ret = rc632_reg_write(ah, 0x00, 0x00);
+	if (ret < 0)
+		return ret;
+
 	/* switch off rf (make sure PICCs are reset at init time) */
 	ret = rc632_power(ah, 0);
 	if (ret < 0)
@@ -762,11 +767,6 @@ rc632_init(struct rfid_asic_handle *ah)
 
 	/* switch on rf */
 	ret = rc632_power(ah, 1);
-	if (ret < 0)
-		return ret;
-
-	/* disable register paging */
-	ret = rc632_reg_write(ah, 0x00, 0x00);
 	if (ret < 0)
 		return ret;
 

--- a/utils/common.c
+++ b/utils/common.c
@@ -81,7 +81,11 @@ int reader_init(void)
 		rh = rfid_reader_open(NULL, RFID_READER_CM5121);
 		if (!rh) {
 			fprintf(stderr, "No Omnikey Cardman 5x21 found\n");
-			return -1;
+			rh = rfid_reader_open("/dev/spidev1.0", RFID_READER_SPIDEV);
+			if(!rh) {
+				fprintf(stderr, "Failed to open spidev1.0\n");
+				return -1;
+			}
 		}
 	}
 	return 0;

--- a/utils/librfid-tool.c
+++ b/utils/librfid-tool.c
@@ -690,7 +690,7 @@ static void help(void)
 		" -d	--dump		dump rc632 registers\n"
 		" -e	--enum		enumerate all tag's in field \n"
 		" -E	--enum-loop	<delay> (ms) enumerate endless\n"
-		" -r	--read		<secror> read iso15693 sector \n\t\t\t(-1:0-255 stop on error, -2: 0-255 no stop)\n"
+		" -r	--read		<sector> read iso15693 sector \n\t\t\t(-1:0-255 stop on error, -2: 0-255 no stop)\n"
         " -w	--write		<sector> write to iso15693 sector data: 01:02:03:04\n"
 		" -h	--help\n");
 }


### PR DESCRIPTION
…y enabled by #define SPIDEV_HALFDUPLEX (maybe it should be made 'configure' option). It should work on all SPI variants, it's just less effective.

Moved register paging before all register accesses.
Added a try to open spidev.
Fixed typo.

Signed-off-by: Alexandr Zarubkin me21@yandex.ru
